### PR TITLE
Use `amountsAreConsistent` extraction to show/hide return assistant header

### DIFF
--- a/ginipaybank/src/main/java/net/gini/pay/bank/capture/digitalinvoice/DigitalInvoiceFragment.kt
+++ b/ginipaybank/src/main/java/net/gini/pay/bank/capture/digitalinvoice/DigitalInvoiceFragment.kt
@@ -99,7 +99,6 @@ open class DigitalInvoiceFragment : Fragment(), DigitalInvoiceScreenContract.Vie
             extractions: Map<String, GiniCaptureSpecificExtraction>,
             compoundExtractions: Map<String, GiniCaptureCompoundExtraction>,
             returnReasons: List<GiniCaptureReturnReason>,
-            isInaccurateExtraction: Boolean = true
         ) = DigitalInvoiceFragment().apply {
             arguments = Bundle().apply {
                 putBundle(ARGS_EXTRACTIONS, Bundle().apply {
@@ -109,6 +108,11 @@ open class DigitalInvoiceFragment : Fragment(), DigitalInvoiceScreenContract.Vie
                     compoundExtractions.forEach { putParcelable(it.key, it.value) }
                 })
                 putParcelableArrayList(ARGS_RETURN_REASONS, ArrayList(returnReasons))
+
+                val isInaccurateExtraction = extractions["amountsAreConsistent"]?.let {
+                    it.value == "false"
+                } ?: true
+
                 putBoolean(ARGS_INACCURATE_EXTRACTION, isInaccurateExtraction)
             }
         }


### PR DESCRIPTION
When this extraction's value is `"false"` it means that the line item
extractions may contain errors and we show a header to the user to
inform them about this.