### PR TITLE
Reflect line item price changes in the total price

### DIFF
--- a/ginipaybank/src/main/java/net/gini/pay/bank/capture/digitalinvoice/DigitalInvoice.kt
+++ b/ginipaybank/src/main/java/net/gini/pay/bank/capture/digitalinvoice/DigitalInvoice.kt
@@ -165,12 +165,17 @@ internal class DigitalInvoice(
     fun lineItemsCurency(): Currency? =
         selectableLineItems.firstOrNull()?.lineItem?.currency
 
-    fun deselectedLineItemsTotalGrossPriceSum(): BigDecimal =
+    private fun deselectedLineItemsTotalGrossPriceSum(): BigDecimal =
         selectableLineItems.fold<SelectableLineItem, BigDecimal>(BigDecimal.ZERO) { sum, sli ->
             if (!sli.selected) sum.add(sli.lineItem.totalGrossPrice) else sum
         }
 
-    fun userAddedLineItemsTotalGrossPriceSum(): BigDecimal =
+    private fun lineItemsTotalGrossPriceDiffs(): BigDecimal =
+        selectableLineItems.fold<SelectableLineItem, BigDecimal>(BigDecimal.ZERO) { sum, sli ->
+            sum.add(sli.lineItem.totalGrossPriceDiff)
+        }
+
+    private fun userAddedLineItemsTotalGrossPriceSum(): BigDecimal =
         selectableLineItems.fold<SelectableLineItem, BigDecimal>(BigDecimal.ZERO) { sum, sli ->
             if (sli.addedByUser) sum.add(sli.lineItem.totalGrossPrice) else sum
         }
@@ -189,6 +194,7 @@ internal class DigitalInvoice(
         if (amountToPay > BigDecimal.ZERO) {
             amountToPay
                 .subtract(deselectedLineItemsTotalGrossPriceSum())
+                .add(lineItemsTotalGrossPriceDiffs())
                 .add(userAddedLineItemsTotalGrossPriceSum())
                 .max(BigDecimal.ZERO)
         } else {


### PR DESCRIPTION
The difference between line items' updated and original total price is
added to the digital invoice's total price.

This way when a line item price is increased then the difference is
added to the total. If it is decreased then it's deducted from the total.

The difference is added for both selected and deselected line items.
Otherwise we wouldn't deduct the correct price for modified deselected
items:

```
1. original price: 10.0; modified price: 12.0; diff: +2.0
2. original price: 8.0; modified price: 7.0; diff: -1.0
Extracted price: 18.0
---
Total: calculated price = extracted price - deselected + total diff
a) both selected:
   => calculated price = 18.0 - 0.0 + 1.0 = 19.0
b) 1. deselected:
   => calculated price = 18.0 - 12.0 + 1.0 = 7.0
c) 2. deselected:
   => calculated price = 18.0 - 7.0 + 1.0 = 12.0
d) both deselected:
   => calculated price = 18.0 - 19.0 + 1.0 = 0.0
```