### PR TITLE
Calculate price diffs only for extracted line items

### DIFF
--- a/ginipaybank/src/main/java/net/gini/pay/bank/capture/digitalinvoice/DigitalInvoice.kt
+++ b/ginipaybank/src/main/java/net/gini/pay/bank/capture/digitalinvoice/DigitalInvoice.kt
@@ -172,7 +172,7 @@ internal class DigitalInvoice(
 
     private fun lineItemsTotalGrossPriceDiffs(): BigDecimal =
         selectableLineItems.fold<SelectableLineItem, BigDecimal>(BigDecimal.ZERO) { sum, sli ->
-            sum.add(sli.lineItem.totalGrossPriceDiff)
+            if (!sli.addedByUser) sum.add(sli.lineItem.totalGrossPriceDiff) else sum
         }
 
     private fun userAddedLineItemsTotalGrossPriceSum(): BigDecimal =


### PR DESCRIPTION
User added line items need to be excluded from the price diff,
otherwise their price is added twice since their price diff is the
same as their price (orig price is 0 so orig - current = current).