### PR TITLE
Pia 1992 update to gradle7 publish plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -216,7 +216,7 @@ pipeline {
             }
             steps {
                 sh '''
-                    ./gradlew ginipaybank:uploadArchives \
+                    ./gradlew publishReleasePublicationToSnapshotsRepository \
                     -PmavenSnapshotsRepoUrl=https://repo.gini.net/nexus/content/repositories/snapshots \
                     -PrepoUser=$NEXUS_MAVEN_USR \
                     -PrepoPassword=$NEXUS_MAVEN_PSW
@@ -244,8 +244,8 @@ pipeline {
             }
             steps {
                 sh '''
-                    ./gradlew ginipaybank:uploadArchives \
-                    -PmavenRepoUrl=https://repo.gini.net/nexus/content/repositories/open \
+                    ./gradlew publishReleasePublicationToOpenRepository \
+                    -PmavenOpenRepoUrl=https://repo.gini.net/nexus/content/repositories/open \
                     -PrepoUser=$NEXUS_MAVEN_USR \
                     -PrepoPassword=$NEXUS_MAVEN_PSW
                 '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,8 +26,8 @@ pipeline {
                     allOf {
                         branch 'main'
                         expression {
-                            def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-                            return !tag.isEmpty()
+                            def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
+                            return status == 0
                         }
                     }
                 }
@@ -45,8 +45,8 @@ pipeline {
                     allOf {
                         branch 'main'
                         expression {
-                            def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-                            return !tag.isEmpty()
+                            def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
+                            return status == 0
                         }
                     }
                 }
@@ -70,8 +70,8 @@ pipeline {
                     allOf {
                         branch 'main'
                         expression {
-                            def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-                            return !tag.isEmpty()
+                            def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
+                            return status == 0
                         }
                     }
                 }
@@ -90,8 +90,8 @@ pipeline {
                     allOf {
                         branch 'main'
                         expression {
-                            def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-                            return !tag.isEmpty()
+                            def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
+                            return status == 0
                         }
                     }
                 }
@@ -112,8 +112,8 @@ pipeline {
                     allOf {
                         branch 'main'
                         expression {
-                            def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-                            return !tag.isEmpty()
+                            def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
+                            return status == 0
                         }
                     }
                 }
@@ -134,8 +134,8 @@ pipeline {
                     allOf {
                         branch 'main'
                         expression {
-                            def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-                            return !tag.isEmpty()
+                            def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
+                            return status == 0
                         }
                     }
                 }
@@ -154,8 +154,8 @@ pipeline {
                     allOf {
                         branch 'main'
                         expression {
-                            def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-                            return !tag.isEmpty()
+                            def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
+                            return status == 0
                         }
                     }
                 }
@@ -174,8 +174,8 @@ pipeline {
 //                    allOf {
 //                        branch 'main'
 //                        expression {
-//                            def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-//                            return !tag.isEmpty()
+//                            def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
+//                            return status == 0
 //                        }
 //                    }
 //                }
@@ -189,8 +189,8 @@ pipeline {
         stage('Release Documentation') {
             when {
                 expression {
-                    def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-                    return !tag.isEmpty()
+                    def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
+                    return status == 0
                 }
                 expression {
                     boolean publish = false
@@ -227,8 +227,8 @@ pipeline {
         stage('Release Library') {
             when {
                 expression {
-                    def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-                    return !tag.isEmpty()
+                    def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
+                    return status == 0
                 }
                 expression {
                     boolean publish = false

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,11 +4,6 @@ pipeline {
     environment {
         NEXUS_MAVEN = credentials('external-nexus-maven-repo-credentials')
         GIT = credentials('github')
-//        COMPONENT_API_EXAMPLE_APP_KEYSTORE_PSW = credentials('gini-vision-library-android_component-api-example-app-release-keystore-password')
-//        COMPONENT_API_EXAMPLE_APP_KEY_PSW = credentials('gini-vision-library-android_component-api-example-app-release-key-password')
-//        SCREEN_API_EXAMPLE_APP_KEYSTORE_PSW = credentials('gini-vision-library-android_screen-api-example-app-release-keystore-password')
-//        SCREEN_API_EXAMPLE_APP_KEY_PSW = credentials('gini-vision-library-android_screen-api-example-app-release-key-password')
-//        EXAMPLE_APP_CLIENT_CREDENTIALS = credentials('gini-vision-library-android_gini-api-client-credentials')
         JAVA11 = '/Library/Java/JavaVirtualMachines/temurin-11.jdk/Contents/Home'
     }
     stages {
@@ -165,27 +160,26 @@ pipeline {
                 archiveArtifacts 'ginipaybank/build/outputs/aar/*.aar,ginipaybank/build/jacoco/testCoverage.zip'
             }
         }
-//        stage('Build Example Apps') {
-//            when {
-//                anyOf {
-//                    not {
-//                        branch 'main'
-//                    }
-//                    allOf {
-//                        branch 'main'
-//                        expression {
-//                            def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
-//                            return status == 0
-//                        }
-//                    }
-//                }
-//            }
-//            steps {
-//                sh './gradlew screenapiexample::clean screenapiexample::assembleRelease -PreleaseKeystoreFile=screen_api_example.jks -PreleaseKeystorePassword="$SCREEN_API_EXAMPLE_APP_KEYSTORE_PSW" -PreleaseKeyAlias=screen_api_example -PreleaseKeyPassword="$SCREEN_API_EXAMPLE_APP_KEY_PSW" -PclientId=$EXAMPLE_APP_CLIENT_CREDENTIALS_USR -PclientSecret=$EXAMPLE_APP_CLIENT_CREDENTIALS_PSW'
-//                sh './gradlew componentapiexample::clean componentapiexample::assembleRelease -PreleaseKeystoreFile=component_api_example.jks -PreleaseKeystorePassword="$COMPONENT_API_EXAMPLE_APP_KEYSTORE_PSW" -PreleaseKeyAlias=component_api_example -PreleaseKeyPassword="$COMPONENT_API_EXAMPLE_APP_KEY_PSW" -PclientId=$EXAMPLE_APP_CLIENT_CREDENTIALS_USR -PclientSecret=$EXAMPLE_APP_CLIENT_CREDENTIALS_PSW'
-//                archiveArtifacts 'screenapiexample/build/outputs/apk/release/screenapiexample-release.apk,componentapiexample/build/outputs/apk/release/componentapiexample-release.apk,screenapiexample/build/outputs/mapping/release/mapping.txt,componentapiexample/build/outputs/mapping/release/mapping.txt'
-//            }
-//        }
+        stage('Build Example Apps') {
+            when {
+                anyOf {
+                    not {
+                        branch 'main'
+                    }
+                    allOf {
+                        branch 'main'
+                        expression {
+                            def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
+                            return status == 0
+                        }
+                    }
+                }
+            }
+            steps {
+                sh './gradlew appscreenapi:clean appscreenapi:assembleDebug -Dorg.gradle.java.home=$JAVA11'
+                sh './gradlew appcomponentapi:clean appcomponentapi:assembleDebug -Dorg.gradle.java.home=$JAVA11'
+            }
+        }
         stage('Release Documentation') {
             when {
                 expression {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
 //        SCREEN_API_EXAMPLE_APP_KEYSTORE_PSW = credentials('gini-vision-library-android_screen-api-example-app-release-keystore-password')
 //        SCREEN_API_EXAMPLE_APP_KEY_PSW = credentials('gini-vision-library-android_screen-api-example-app-release-key-password')
 //        EXAMPLE_APP_CLIENT_CREDENTIALS = credentials('gini-vision-library-android_gini-api-client-credentials')
-        JAVA9 = '/Users/mobilecd/java-vm/jdk-9.0.4.jdk/Contents/Home'
+        JAVA11 = '/Library/Java/JavaVirtualMachines/temurin-11.jdk/Contents/Home'
     }
     stages {
         stage('Import Pipeline Libraries') {
@@ -33,7 +33,7 @@ pipeline {
                 }
             }
             steps {
-                sh './gradlew clean ginipaybank:assembleDebug ginipaybank:assembleRelease'
+                sh './gradlew clean ginipaybank:assembleDebug ginipaybank:assembleRelease -Dorg.gradle.java.home=$JAVA11'
             }
         }
         stage('Unit Tests') {
@@ -52,7 +52,7 @@ pipeline {
                 }
             }
             steps {
-                sh './gradlew ginipaybank:testDebugUnitTest -Dorg.gradle.java.home=$JAVA9'
+                sh './gradlew ginipaybank:testDebugUnitTest -Dorg.gradle.java.home=$JAVA11'
             }
             post {
                 always {
@@ -77,7 +77,7 @@ pipeline {
                 }
             }
             steps {
-                sh './gradlew ginipaybank:jacocoTestDebugUnitTestReport -Dorg.gradle.java.home=$JAVA9'
+                sh './gradlew ginipaybank:jacocoTestDebugUnitTestReport -Dorg.gradle.java.home=$JAVA11'
                 publishHTML([allowMissing: false, alwaysLinkToLastBuild: false, keepAll: true, reportDir: 'ginipaybank/build/jacoco/jacocoHtml', reportFiles: 'index.html', reportName: 'Code Coverage Report', reportTitles: ''])
             }
         }
@@ -97,7 +97,7 @@ pipeline {
                 }
             }
             steps {
-                sh './gradlew ginipaybank:lint ginipaybank:checkstyle ginipaybank:pmd'
+                sh './gradlew ginipaybank:lint ginipaybank:checkstyle ginipaybank:pmd -Dorg.gradle.java.home=$JAVA11'
                 androidLint canComputeNew: false, defaultEncoding: '', healthy: '', pattern: 'ginipaybank/build/reports/lint-results.xml', unHealthy: ''
                 checkstyle canComputeNew: false, defaultEncoding: '', healthy: '', pattern: 'ginipaybank/build/reports/checkstyle/checkstyle.xml', unHealthy: ''
                 pmd canComputeNew: false, defaultEncoding: '', healthy: '', pattern: 'ginipaybank/build/reports/pmd/pmd.xml', unHealthy: ''
@@ -141,7 +141,7 @@ pipeline {
                 }
             }
             steps {
-                sh './gradlew ginipaybank:dokkaHtml'
+                sh './gradlew ginipaybank:dokkaHtml -Dorg.gradle.java.home=$JAVA11'
                 publishHTML([allowMissing: false, alwaysLinkToLastBuild: false, keepAll: true, reportDir: 'ginipaybank/build/dokka/ginipaybank', reportFiles: 'index.html', reportName: 'Gini Pay Bank KDoc', reportTitles: ''])
             }
         }
@@ -195,7 +195,7 @@ pipeline {
                 expression {
                     boolean publish = false
                     try {
-                        def version = sh(returnStdout: true, script: './gradlew -q printLibraryVersion').trim()
+                        def version = sh(returnStdout: true, script: './gradlew -q printLibraryVersion -Dorg.gradle.java.home=$JAVA11').trim()
                         def sha = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
                         input "Release documentation for ${version} from branch ${env.BRANCH_NAME} commit ${sha}?"
                         publish = true
@@ -219,7 +219,8 @@ pipeline {
                     ./gradlew publishReleasePublicationToSnapshotsRepository \
                     -PmavenSnapshotsRepoUrl=https://repo.gini.net/nexus/content/repositories/snapshots \
                     -PrepoUser=$NEXUS_MAVEN_USR \
-                    -PrepoPassword=$NEXUS_MAVEN_PSW
+                    -PrepoPassword=$NEXUS_MAVEN_PSW \
+                    -Dorg.gradle.java.home=$JAVA11
                 '''
             }
         }
@@ -232,7 +233,7 @@ pipeline {
                 expression {
                     boolean publish = false
                     try {
-                        def version = sh(returnStdout: true, script: './gradlew -q printLibraryVersion').trim()
+                        def version = sh(returnStdout: true, script: './gradlew -q printLibraryVersion -Dorg.gradle.java.home=$JAVA11').trim()
                         def sha = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
                         input "Release ${version} from branch ${env.BRANCH_NAME} commit ${sha}?"
                         publish = true
@@ -247,7 +248,8 @@ pipeline {
                     ./gradlew publishReleasePublicationToOpenRepository \
                     -PmavenOpenRepoUrl=https://repo.gini.net/nexus/content/repositories/open \
                     -PrepoUser=$NEXUS_MAVEN_USR \
-                    -PrepoPassword=$NEXUS_MAVEN_PSW
+                    -PrepoPassword=$NEXUS_MAVEN_PSW \
+                    -Dorg.gradle.java.home=$JAVA11
                 '''
             }
         }

--- a/appcomponentapi/build.gradle
+++ b/appcomponentapi/build.gradle
@@ -51,7 +51,6 @@ repositories {
 
 dependencies {
     implementation project(":ginipaybank")
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
 
     implementation "androidx.appcompat:appcompat:${versions.appcompat}"
     implementation "androidx.activity:activity-ktx:${versions.activity}"

--- a/appcomponentapi/src/main/java/net/gini/pay/appcomponentapi/review/MultiPageReviewExampleActivity.kt
+++ b/appcomponentapi/src/main/java/net/gini/pay/appcomponentapi/review/MultiPageReviewExampleActivity.kt
@@ -4,11 +4,13 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.commit
+import net.gini.android.capture.GiniCaptureError
 import net.gini.android.capture.document.GiniCaptureMultiPageDocument
 import net.gini.android.capture.review.multipage.MultiPageReviewFragment
 import net.gini.android.capture.review.multipage.MultiPageReviewFragmentListener
@@ -48,6 +50,11 @@ class MultiPageReviewExampleActivity : AppCompatActivity(), MultiPageReviewFragm
     }
 
     override fun onImportedDocumentReviewCancelled() {
+        finish()
+    }
+
+    override fun onError(error: GiniCaptureError) {
+        Log.e("GiniCapture", error.message)
         finish()
     }
 

--- a/appscreenapi/build.gradle
+++ b/appscreenapi/build.gradle
@@ -51,7 +51,6 @@ repositories {
 
 dependencies {
     implementation project(":ginipaybank")
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
 
     implementation "androidx.appcompat:appcompat:${versions.appcompat}"
     implementation "androidx.activity:activity-ktx:${versions.activity}"

--- a/appscreenapi/build.gradle
+++ b/appscreenapi/build.gradle
@@ -59,9 +59,9 @@ dependencies {
     implementation "com.google.android.material:material:${versions.material}"
 
     def koinVersion = '2.2.2'
-    implementation "org.koin:koin-androidx-scope:$koinVersion"
-    implementation "org.koin:koin-androidx-viewmodel:$koinVersion"
-    implementation "org.koin:koin-androidx-fragment:$koinVersion"
+    implementation "io.insert-koin:koin-androidx-scope:$koinVersion"
+    implementation "io.insert-koin:koin-androidx-viewmodel:$koinVersion"
+    implementation "io.insert-koin:koin-androidx-fragment:$koinVersion"
 
     testImplementation "junit:junit:${versions.junit}"
     androidTestImplementation "androidx.test.ext:junit:${versions.androidxTestJunit}"

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext.versions = [
             "compileSdk": 30,
-            "minSdk": 19,
+            "minSdk": 21,
             "targetSdk": 30,
 
             "kotlin": '1.5.21',

--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,8 @@ buildscript {
             "kotlin": '1.5.21',
             "androidGradlePlugin": '4.2.2',
 
-            "capture": "1.2.0",
-            "payapi": "1.0.0-beta05",
+            "capture": "1.3.0",
+            "payapi": "1.0.0",
 
             "core": '1.6.0',
             "appcompat": '1.3.0',

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        maven { url "https://dl.bintray.com/kotlin/dokka" }
         mavenCentral()
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
             "targetSdk": 30,
 
             "kotlin": '1.5.21',
-            "androidGradlePlugin": '4.2.2',
+            "androidGradlePlugin": '7.0.0',
 
             "capture": "1.3.0",
             "payapi": "1.0.0",

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,6 @@ allprojects {
         google()
         maven { url "https://dl.bintray.com/kotlin/dokka" }
         mavenCentral()
-        jcenter()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
             "minSdk": 19,
             "targetSdk": 30,
 
-            "kotlin": '1.5.20',
+            "kotlin": '1.5.21',
             "androidGradlePlugin": '4.2.2',
 
             "capture": "1.2.0",

--- a/ginipaybank/build.gradle
+++ b/ginipaybank/build.gradle
@@ -56,9 +56,6 @@ repositories {
 }
 
 dependencies {
-
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
-
     api "net.gini:gini-capture-sdk:${versions.capture}"
     api "net.gini:gini-capture-network-lib:${versions.capture}"
     api "net.gini:gini-capture-accounting-network-lib:${versions.capture}"

--- a/ginipaybank/build.gradle
+++ b/ginipaybank/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'kotlin-parcelize'
     id 'com.hiya.jacoco-android'
     id 'org.jetbrains.dokka'
+    id 'maven-publish'
 }
 
 jacoco {
@@ -79,7 +80,6 @@ dependencies {
 
 
 apply from: rootProject.file('gradle/codequality.gradle')
-apply from: rootProject.file('gradle/maven.gradle')
 apply from: rootProject.file('gradle/multidex_for_tests.gradle')
 
 dokkaHtml {
@@ -117,7 +117,4 @@ task javadocJar(type: Jar, dependsOn: dokkaJavadoc) {
     from dokkaJavadoc.outputDirectory
 }
 
-artifacts {
-    archives sourcesJar
-    archives javadocJar
-}
+apply from: rootProject.file('gradle/maven.gradle')

--- a/ginipaybank/src/main/java/net/gini/pay/bank/capture/Configuration.kt
+++ b/ginipaybank/src/main/java/net/gini/pay/bank/capture/Configuration.kt
@@ -106,7 +106,7 @@ data class CaptureConfiguration(
     /**
      * A list of [HelpItem.Custom] defining the custom help items to be shown in the Help Screen.
      */
-    val customHelpItems: List<HelpItem.Custom>,
+    val customHelpItems: List<HelpItem.Custom> = emptyList(),
 )
 
 internal fun GiniCapture.Builder.applyConfiguration(configuration: CaptureConfiguration): GiniCapture.Builder {

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,3 +22,6 @@ kotlin.code.style=official
 
 groupId=net.gini
 version=1.1.0
+
+android.useAndroidX=true
+android.enableJetifier=true

--- a/gradle/git_utils.gradle
+++ b/gradle/git_utils.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'org.ajoberstar:grgit:1.5.0'

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -1,71 +1,85 @@
-apply plugin: 'maven'
-
-// In order to upload to the repo, you can create a file ~/.gradle/gradle.properties with
-//
+// Publishing requires the following parameters (you can either pass them in as gradle parameters with -P<paramName>=...
+// or you can add them to a gradle.properties file (for ex. in your global ~/.gradle/gradle.properties file)):
 // repoUser=<your user name>
 // repoPassword=<your password>
-// mavenSnapshotsRepoUrl=<url for snapshots>
-// mavenRepoUrl=<url for releases>
-// mavenLocalRepoUrl=<url for local releases>
-uploadArchives {
-    repositories {
-        mavenDeployer {
-            pom.groupId = groupId
-            pom.artifactId = artifactId
-            pom.version = version
-            if (project.hasProperty('devVersionSuffix')) {
-                pom.version = "${pom.version}.${devVersionSuffix}"
-            }
-            if (project.hasProperty('mavenSnapshotsRepoUrl')) {
-                pom.version = "${pom.version}-SNAPSHOT"
-            }
+//
+// Also at least one of the following parameters are required:
+// mavenOpenRepoUrl=<URL>
+// mavenSnapshotsRepoUrl=<URL>
+// mavenLocalRepoUrl=<URL>
 
-            pom.project {
-                licenses {
-                    license {
-                        name 'Private License'
-                        url 'https://raw.githubusercontent.com/gini/gini-pay-bank-sdk-android/master/LICENSE.md'
-                        distribution 'repo'
+// Because the components are created only during the afterEvaluate phase, we must
+// configure our publications using the afterEvaluate() lifecycle method
+afterEvaluate {
+
+    // Create source and javadoc artifacts
+    def sourcesArtifact = artifacts.add('archives', sourcesJar)
+    def javadocArtifact = artifacts.add('archives', javadocJar)
+
+    publishing {
+        publications {
+            // Creates a Maven publication called "release"
+            release(MavenPublication) {
+                // Applies the component for the release build variant
+                from components.release
+
+                // Adds additional artifacts
+                artifact sourcesArtifact
+                artifact javadocArtifact
+
+                // Customizes attributes of the publication
+                groupId = project.groupId
+                artifactId = project.artifactId
+                version = project.version
+
+                if (project.hasProperty('devVersionSuffix')) {
+                    version = "${version}.${devVersionSuffix}"
+                }
+                if (project.hasProperty('mavenSnapshotsRepoUrl')) {
+                    version = "${version}-SNAPSHOT"
+                }
+
+                pom {
+                    licenses {
+                        license {
+                            name = 'Private License'
+                            url = 'https://raw.githubusercontent.com/gini/gini-pay-bank-sdk-android/master/LICENSE.md'
+                            distribution = 'repo'
+                        }
+                    }
+                    organization {
+                        name = 'Gini GmbH'
+                        url = 'https://www.gini.net/'
                     }
                 }
-                organization {
-                    name 'Gini GmbH'
-                    url 'https://www.gini.net/'
-                }
             }
+        }
 
-            pom.whenConfigured { pom ->
-                pom.dependencies.forEach { dep ->
-                    if (dep.getArtifactId().startsWith("gini-")) {
-                        dep.setGroupId(groupId)
+        repositories {
+            if (project.hasProperty('mavenOpenRepoUrl')) {
+                maven {
+                    name = "open"
+                    url = mavenOpenRepoUrl
+                    credentials {
+                        username = project.hasProperty('repoUser') ? repoUser : 'invalidUserName'
+                        password = project.hasProperty('repoPassword') ? repoPassword : 'invalidPassword'
                     }
                 }
             }
-
             if (project.hasProperty('mavenSnapshotsRepoUrl')) {
-                repository(url: mavenSnapshotsRepoUrl) {
-                    authentication(
-                            userName: project.hasProperty('repoUser') ? repoUser : "invalidUserName",
-                            password: project.hasProperty('repoPassword') ? repoPassword : "invalidPassword"
-                    )
+                maven {
+                    name = "snapshots"
+                    url = mavenSnapshotsRepoUrl
+                    credentials {
+                        username = project.hasProperty('repoUser') ? repoUser : 'invalidUserName'
+                        password = project.hasProperty('repoPassword') ? repoPassword : 'invalidPassword'
+                    }
                 }
             }
-
-            if (project.hasProperty('mavenRepoUrl')) {
-                repository(url: mavenRepoUrl) {
-                    authentication(
-                            userName: project.hasProperty('repoUser') ? repoUser : 'invalidUserName',
-                            password: project.hasProperty('repoPassword') ? repoPassword : 'invalidPassword'
-                    )
-                }
-            }
-
             if (project.hasProperty('mavenLocalRepoUrl')) {
-                repository(url: mavenLocalRepoUrl) {
-                    authentication(
-                            userName: project.hasProperty('repoUser') ? repoUser : 'invalidUserName',
-                            password: project.hasProperty('repoPassword') ? repoPassword : 'invalidPassword'
-                    )
+                maven {
+                    name = "local"
+                    url = mavenLocalRepoUrl
                 }
             }
         }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip


### PR DESCRIPTION
Please review after #28.

* Migrate to gradle 7 and replace the old maven plugin with the new `maven-publish` plugin for publishing releases to our own maven repository.
* Update the Android Gradle Plugin to the latest version (7.0.0) and use the required Java 11 to run gradle.
* Use Capture SDK 1.3.0 and Pay Api Lib 1.0.0.
* Make the custom help items configuration optional.
* Fix component api example.
* Reenable example app builds in Jenkinsfile.

### Ticket 
https://ginis.atlassian.net/browse/PIA-1192
