### PR TITLE
Target sdk version 31 (Android 12) and set `android:exported` attribute

### DIFF
--- a/appcomponentapi/src/main/AndroidManifest.xml
+++ b/appcomponentapi/src/main/AndroidManifest.xml
@@ -30,7 +30,8 @@
         android:theme="@style/AppTheme.NoActionBar">
         <activity
             android:name=".MainActivity"
-            android:theme="@style/AppTheme">
+            android:theme="@style/AppTheme"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/appscreenapi/src/main/AndroidManifest.xml
+++ b/appscreenapi/src/main/AndroidManifest.xml
@@ -28,7 +28,8 @@
         android:supportsRtl="true"
         android:name=".ExampleApplication"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -52,7 +53,8 @@
                 <data android:mimeType="application/pdf" />
             </intent-filter>
         </activity>
-        <activity android:name=".pay.PayActivity">
+        <activity android:name=".pay.PayActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,9 @@
 
 buildscript {
     ext.versions = [
-            "compileSdk": 30,
+            "compileSdk": 31,
             "minSdk": 21,
-            "targetSdk": 30,
+            "targetSdk": 31,
 
             "kotlin": '1.5.21',
             "androidGradlePlugin": '7.0.0',


### PR DESCRIPTION
When targeting Android 12 activities with intent filters require
the `android:exported` attribute:
https://developer.android.com/about/versions/12/behavior-changes-12#exported